### PR TITLE
kbd.c: Remove duplicate line

### DIFF
--- a/kbd.c
+++ b/kbd.c
@@ -34,8 +34,6 @@ struct map_element	*ele;
 struct key		 key;
 int			 rptcount;
 
-int		 rptcount;
-
 /*
  * Toggle the value of use_metakey
  */


### PR DESCRIPTION
The last merge from OpenBSD upstream (commit a2b666c) left a duplicate
variable declaration.