### PR TITLE
Weird query-replace bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-packages
-*.o
-mg
-mg-static/mg-*
-build/
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-*~
+packages
+*.o
+mg
+mg-static/mg-*
+build/

--- a/line.c
+++ b/line.c
@@ -579,7 +579,7 @@ lreplace(RSIZE plen, char *st)
 
 	for (n = 0, is_replace_alllower = 1; n < rlen && is_replace_alllower;
 	    n++)
-		is_replace_alllower = !isupper((unsigned char)repl[n]);
+		is_replace_alllower = isupper((unsigned char)repl[n]);
 
 	if (is_replace_alllower) {
 		if (is_query_allcaps) {


### PR DESCRIPTION
Greetings,

I would normally report this to upstream but i don't daily drive OpenBSD so i don't have sendbug utility.

Try to query replace same word from fully capitalized to fully lowercase, it doesn't work.
query-replace TEST test

Problem lies within line.c:582, now everything works at it should.

Thank your for your time,
Aleksandar M.